### PR TITLE
Switch to getBoundingClientRect so arrows get drawn correctly in scroll areas

### DIFF
--- a/src/lib/geometry/rectangle.js
+++ b/src/lib/geometry/rectangle.js
@@ -41,11 +41,7 @@ Rectangle.SIDES = {
 };
 
 function findAbsolutePosition(htmlElement) {
-  for (var x = 0, y = 0, el = htmlElement; el != null; el = el.offsetParent) {
-    x += el.offsetLeft;
-    y += el.offsetTop;
-  }
-
+  const {x, y} = htmlElement.getBoundingClientRect();
   return new Point(x,y);
 }
 


### PR DESCRIPTION
When targeting two elements inside a scrolled containers, the arrow is drawn in the incorrect position because scroll isn't taken into account when using offset values.

Using `getBoundingClientRect();` does take those into account, so now arrows get drawn correctly even when connecting two elements in a scrolled container.